### PR TITLE
Defer Element.matches feature detection to runtime

### DIFF
--- a/src/main/js/ephox/sugar/api/search/Selectors.js
+++ b/src/main/js/ephox/sugar/api/search/Selectors.js
@@ -11,27 +11,6 @@ define(
   ],
 
   function (Arr, Option, Element, NodeTypes, Error, document) {
-    /*
-     * There's a lot of code here; the aim is to allow the browser to optimise constant comparisons,
-     * instead of doing object lookup feature detection on every call
-     */
-    var STANDARD = 0;
-    var MSSTANDARD = 1;
-    var WEBKITSTANDARD = 2;
-    var FIREFOXSTANDARD = 3;
-
-    var selectorType = (function () {
-      var test = document.createElement('span');
-      // As of Chrome 34 / Safari 7.1 / FireFox 34, everyone except IE has the unprefixed function.
-      // Still check for the others, but do it last.
-      return test.matches !== undefined ? STANDARD :
-             test.msMatchesSelector !== undefined ? MSSTANDARD :
-             test.webkitMatchesSelector !== undefined ? WEBKITSTANDARD :
-             test.mozMatchesSelector !== undefined ? FIREFOXSTANDARD :
-             -1;
-    })();
-
-
     var ELEMENT = NodeTypes.ELEMENT;
     var DOCUMENT = NodeTypes.DOCUMENT;
 
@@ -41,10 +20,10 @@ define(
 
       // As of Chrome 34 / Safari 7.1 / FireFox 34, everyone except IE has the unprefixed function.
       // Still check for the others, but do it last.
-      else if (selectorType === STANDARD) return elem.matches(selector);
-      else if (selectorType === MSSTANDARD) return elem.msMatchesSelector(selector);
-      else if (selectorType === WEBKITSTANDARD) return elem.webkitMatchesSelector(selector);
-      else if (selectorType === FIREFOXSTANDARD) return elem.mozMatchesSelector(selector);
+      else if (elem.matches !== undefined) return elem.matches(selector);
+      else if (elem.msMatchesSelector !== undefined) return elem.msMatchesSelector(selector);
+      else if (elem.webkitMatchesSelector !== undefined) return elem.webkitMatchesSelector(selector);
+      else if (elem.mozMatchesSelector !== undefined) return elem.mozMatchesSelector(selector);
       else throw new Error('Browser lacks native selectors'); // unfortunately we can't throw this on startup :(
     };
 


### PR DESCRIPTION
When another library (such as MediaElement.js) [polyfills](https://github.com/mediaelement/mediaelement/blob/8e1e99dcc12f658f1cb06ec4c205ebd277db5847/src/js/utils/polyfill.js#L86-L101) `Element.prototype.matches` in the `window` then the library detects that `selectorType` is `STANDARD`. However, this cached feature detection then gets gets carried into the `is` function in the editor iframe window where the `matches` polyfill may not be applied, and then a JS error results from `matches` not being defined.

So the feature detection needs to be deferred to runtime to ensure that it accounts for polyfills for `matches` being inconsistently applied.

Patch committed to WordPress core for the 4.9 release: https://core.trac.wordpress.org/changeset/42191

Originally reported in https://core.trac.wordpress.org/ticket/42553