### PR TITLE
Fixed getPropertyValue method missing on a style object if style is not a dom object

### DIFF
--- a/src/main/ts/ephox/sugar/impl/Style.ts
+++ b/src/main/ts/ephox/sugar/impl/Style.ts
@@ -2,7 +2,9 @@ import { HTMLElement } from "@ephox/dom-globals";
 
 // some elements, such as mathml, don't have style attributes
 var isSupported = function (dom: HTMLElement) {
-  return dom.style !== undefined;
+  return dom.style !== undefined 
+    && dom.style.constructor !== undefined
+	&& dom.style.constructor.name === 'CSSStyleDeclaration';
 };
 
 export default {


### PR DESCRIPTION
Sugar library is used in the tinymce editor to determine the font-family and font-size properties of the selected element.

Unfortunately it fails to handle the style property of an element which is a part of angular dom (such style is not an instance of CSSStyleDeclaration): https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty

The callstack with the error returned to the console is:

```
webpack-internal:///1:1896 ERROR TypeError: dom.style.getPropertyValue is not a function
    at getUnsafeProperty (webpack-internal:///742:3734:43)
    at getRaw (webpack-internal:///742:3738:17)
    at getProperty (webpack-internal:///742:12907:16)
    at eval (webpack-internal:///742:12913:16)
    at ancestor (webpack-internal:///742:7071:13)
    at ClosestOrAncestor (webpack-internal:///742:7062:104)
    at closest (webpack-internal:///742:7082:14)
    at getSpecifiedFontProp (webpack-internal:///742:12912:14)
    at eval (webpack-internal:///742:12935:18)
    at Object.bind (webpack-internal:///742:126:16)
    at eval (webpack-internal:///742:12934:75)
    at Object.eval [as getFontFamily] (webpack-internal:///742:18:22)
    at eval (webpack-internal:///742:12988:25)
    at Object.fold (webpack-internal:///742:130:18)
    at fontNameQuery (webpack-internal:///742:12983:38)
    at EditorCommands.eval (webpack-internal:///742:13872:16)
    at commands.value.(anonymous function) (webpack-internal:///742:13608:27)
    at EditorCommands.queryCommandValue (webpack-internal:///742:13567:18)
    at Editor.queryCommandValue (webpack-internal:///742:24681:36)
```

To fix the problem, checking if style is not undefined must be narrowed down to check if the style is the expected CSSStyleDeclaration object otherwise calling methods such as getPropertyValue, setProperty, removeProperty etc. will cause exceptions.

Please include this fix in the sugar library and use the updated version of the library in the next tinymce release as this issue causes problems when tinyce tries to get computed style of a selected element.

I already given permission to use the code in tinymce (accepted the agreement to share the code licence)
